### PR TITLE
fix: Set burn to 90% and set weights excluding validator uids

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -830,7 +830,7 @@ class Validator:
             index = miner_uids.index(self.uid) + 1
             final_weights[index] = 0
 
-        bt.logging.info(f"Burn applied: 75% of total weight ({burn_weight_portion:.4f}) redirected to UID 238")
+bt.logging.info(f"Burn applied: 90% of total weight ({burn_weight_portion:.4f}) redirected to UID 238")
 
         miner_credibilities = credibilities.squeeze()[miner_uids]
         # Extend credibilities to match (burn entry has no credibility)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -882,10 +882,10 @@ bt.logging.info(f"Burn applied: 90% of total weight ({burn_weight_portion:.4f}) 
                 )
             else:
                 # Display original score for miner UIDs with defensive check
-                if uid < len(scores):
+                if uid in miner_uids:
                     original_score = scores[uid].item()
                 else:
-                    bt.logging.warning(f"UID {uid} not found in scores tensor (length: {len(scores)})")
+                    bt.logging.warning(f"UID {uid} is not a miner UID; displaying score as 0")
                     original_score = 0
 
                 # Display credibility with error handling

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -688,10 +688,9 @@ class Validator:
                 )
                 return True
             
-            # Check if 3600 blocks have passed since last weight setting
             if blocks_since_last_weights >= blocks_per_weight_cycle:
                 bt.logging.info(
-                    f"3600-block cycle reached: current_block={current_block}, "
+                    f"{blocks_per_weight_cycle}-block cycle reached: current_block={current_block}, "
                     f"last_weights_set_block={self.last_weights_set_block}, "
                     f"blocks_since_last_weights={blocks_since_last_weights}"
                 )


### PR DESCRIPTION
- Update `set_weight()` method to accept scores from `update_bittensor_weights_from_zipcode_scores()` method
- Filter out validator uids before setting weights.

Fixed 
#17 3621865978